### PR TITLE
Remove ambiguity from: requestFrom(uint8_t addr, int size)

### DIFF
--- a/src/BBQ10Keyboard.cpp
+++ b/src/BBQ10Keyboard.cpp
@@ -170,7 +170,7 @@ uint8_t BBQ10Keyboard::readRegister8(uint8_t reg) const
     m_wire->write(reg);
     m_wire->endTransmission();
 
-    m_wire->requestFrom((uint8_t)m_addr, (uint8_t)1);
+    m_wire->requestFrom(m_addr, 1u);
     if (m_wire->available() < 1)
         return 0;
 
@@ -183,7 +183,7 @@ uint16_t BBQ10Keyboard::readRegister16(uint8_t reg) const
     m_wire->write(reg);
     m_wire->endTransmission();
 
-    m_wire->requestFrom((uint8_t)m_addr, (uint8_t)2);
+    m_wire->requestFrom(m_addr, 2u);
     if (m_wire->available() < 2)
         return 0;
 

--- a/src/BBQ10Keyboard.cpp
+++ b/src/BBQ10Keyboard.cpp
@@ -170,7 +170,7 @@ uint8_t BBQ10Keyboard::readRegister8(uint8_t reg) const
     m_wire->write(reg);
     m_wire->endTransmission();
 
-    m_wire->requestFrom(m_addr, 1);
+    m_wire->requestFrom((uint8_t)m_addr, (uint8_t)1);
     if (m_wire->available() < 1)
         return 0;
 
@@ -183,7 +183,7 @@ uint16_t BBQ10Keyboard::readRegister16(uint8_t reg) const
     m_wire->write(reg);
     m_wire->endTransmission();
 
-    m_wire->requestFrom(m_addr, 2);
+    m_wire->requestFrom((uint8_t)m_addr, (uint8_t)2);
     if (m_wire->available() < 2)
         return 0;
 


### PR DESCRIPTION
I was seeing this error:
In file included from /Users/jameswolf/Documents/Arduino/libraries/BBQ10Keyboard/src/BBQ10Keyboard.h:1,
                 from /Users/jameswolf/Documents/Arduino/libraries/BBQ10Keyboard/src/BBQ10Keyboard.cpp:3:
/Users/jameswolf/Library/Arduino15/packages/esp32/hardware/esp32/2.0.9/libraries/Wire/src/Wire.h: In member function 'uint8_t BBQ10Keyboard::readRegister8(uint8_t) const':
/Users/jameswolf/Library/Arduino15/packages/esp32/hardware/esp32/2.0.9/libraries/Wire/src/Wire.h:127:13: note: candidate 1: 'uint8_t TwoWire::requestFrom(int, int)'
     uint8_t requestFrom(int address, int size);
             ^~~~~~~~~~~
/Users/jameswolf/Library/Arduino15/packages/esp32/hardware/esp32/2.0.9/libraries/Wire/src/Wire.h:125:13: note: candidate 2: 'uint8_t TwoWire::requestFrom(uint8_t, uint8_t)'
     uint8_t requestFrom(uint8_t address, uint8_t size);
             ^~~~~~~~~~~
/Users/jameswolf/Library/Arduino15/packages/esp32/hardware/esp32/2.0.9/libraries/Wire/src/Wire.h: In member function 'uint16_t BBQ10Keyboard::readRegister16(uint8_t) const':
/Users/jameswolf/Library/Arduino15/packages/esp32/hardware/esp32/2.0.9/libraries/Wire/src/Wire.h:127:13: note: candidate 1: 'uint8_t TwoWire::requestFrom(int, int)'
     uint8_t requestFrom(int address, int size);
             ^~~~~~~~~~~
/Users/jameswolf/Library/Arduino15/packages/esp32/hardware/esp32/2.0.9/libraries/Wire/src/Wire.h:125:13: note: candidate 2: 'uint8_t TwoWire::requestFrom(uint8_t, uint8_t)'
     uint8_t requestFrom(uint8_t address, uint8_t size);
             ^~~~~~~~~~~
             
 Seemed to suggest that on my micro (LilyGo t-display S3) the signature could not be determined to be one or the other (which seems dumb, but whatever).  On my machine setting them as both cast to uint8_t solved the issue.  Thought I might share it in case someone else was having a similar issue.